### PR TITLE
Increase worker nodes to 3

### DIFF
--- a/scenarios/olvm/deployments/1cp3worker/clusterConfigTemplate.yaml
+++ b/scenarios/olvm/deployments/1cp3worker/clusterConfigTemplate.yaml
@@ -1,5 +1,5 @@
 name: 1cp3worker
-workerNodes: 1
+workerNodes: 3
 controlPlaneNodes: 1
 virtualIp: $OLVM_VIRTUAL_IP
 provider: olvm


### PR DESCRIPTION
The tests require at least three worker nodes to run.  