### PR TITLE
Get basic k8s_test.sh working for the OLVM provider

### DIFF
--- a/tests/upgrade/tests.bats
+++ b/tests/upgrade/tests.bats
@@ -169,8 +169,15 @@ doCapiUpgrade() {
 	CP_NAMESPACE="${lines[2]}"
 	waitFor kubeadmcontrolplane "$CP_NAMESPACE" "$CP_NAME"
 
-	# Validate Kubernetes Version
+	# Temporary work around for the OLVM provider - sometimes a node that was upgraded
+	# to a newer Kubernetes version remains visible and in the state "NotReady,SchedulingDisabled".
+	# However, the VM associated withe node has been deleted. Delete any nodes in this state.
 	export KUBECONFIG="$TARGET_KUBECONFIG"
+    for node in $(kubectl --kubeconfig $KUBECONFIG get nodes | grep SchedulingDisabled | awk '{print $1}'); do
+        kubectl delete $node
+    done
+
+	# Validate Kubernetes Version
 	run -0 kubectl version -o yaml
 	VERSION_INFO="$output"
 	run -0 bats_pipe echo "$VERSION_INFO" \| yq .serverVersion.major

--- a/tests/upgrade/tests.bats
+++ b/tests/upgrade/tests.bats
@@ -174,7 +174,7 @@ doCapiUpgrade() {
 	# However, the VM associated withe node has been deleted. Delete any nodes in this state.
 	export KUBECONFIG="$TARGET_KUBECONFIG"
     for node in $(kubectl --kubeconfig $KUBECONFIG get nodes | grep SchedulingDisabled | awk '{print $1}'); do
-        kubectl delete $node
+        kubectl delete node $node
     done
 
 	# Validate Kubernetes Version

--- a/tools/basic_k8s_test.sh
+++ b/tools/basic_k8s_test.sh
@@ -25,7 +25,7 @@ if [[ ! -z ${TLS13} ]]; then
 	fi
 fi
 
-CURL=(curl '"$TLS13"' '*' --fail --max-time 10 --silent --output /dev/null --write-out '%{http_code}\\n')
+CURL=(curl "$TLS13" '*' --fail --max-time 10 --silent --output /dev/null --write-out '%{http_code}\\n')
 
 if [ -z "${KUBECONFIG}" ]; then
     # set default kubeconfig location

--- a/tools/basic_k8s_test.sh
+++ b/tools/basic_k8s_test.sh
@@ -363,7 +363,7 @@ function print_help() {
 };
 
 function validate_ks_pods() {
-    for i in $(seq 10); do
+    for i in $(seq 20); do
         all_pods=$(kubectl get po -n kube-system --no-headers)
         number_of_running_pods=$(logInfo "${all_pods}" | grep Running | wc -l)
         number_of_total_pods=$(logInfo "${all_pods}" | wc -l)

--- a/tools/basic_k8s_test.sh
+++ b/tools/basic_k8s_test.sh
@@ -363,7 +363,7 @@ function print_help() {
 };
 
 function validate_ks_pods() {
-    for i in $(seq 20); do
+    for i in $(seq 10); do
         all_pods=$(kubectl get po -n kube-system --no-headers)
         number_of_running_pods=$(logInfo "${all_pods}" | grep Running | wc -l)
         number_of_total_pods=$(logInfo "${all_pods}" | wc -l)


### PR DESCRIPTION
The upgrade tests for OLVM provider are sometimes working with these changes.  There are some intermittent issues in OLVM or CAPI that cause the upgrade tests to fail due to an old node remaining in a SchedulingDisabled state.