### PR TITLE
Enable upgrade tests for OLVM

### DIFF
--- a/tests/upgrade/tests.bats
+++ b/tests/upgrade/tests.bats
@@ -270,6 +270,46 @@ stageOlvm() {
 	ocne cluster show -C $(yq -e .name $CLUSTER_CONFIG) -f "config.providers.olvm"
 }
 
+@test "Basic Kubernetes Tests for 1.26" {
+	doSkip 1.26
+	export KUBECONFIG="$TARGET_KUBECONFIG"
+	basic_k8s_test.sh
+}
+
+@test "Upgrade to 1.27" {
+	doUpgrade 1.27
+}
+
+@test "Basic Kubernetes Tests for 1.27" {
+	doSkip 1.27
+	export KUBECONFIG="$TARGET_KUBECONFIG"
+	basic_k8s_test.sh
+}
+
+@test "Upgrade to 1.28" {
+	doUpgrade 1.28
+}
+
+@test "Basic Kubernetes Tests for 1.28" {
+	doSkip 1.28
+	export KUBECONFIG="$TARGET_KUBECONFIG"
+	basic_k8s_test.sh
+}
+
+@test "Upgrade to 1.29" {
+	doUpgrade 1.29
+}
+
+@test "Basic Kubernetes Tests for 1.29" {
+	doSkip 1.29
+	export KUBECONFIG="$TARGET_KUBECONFIG"
+	basic_k8s_test.sh
+}
+
+@test "Upgrade to 1.30" {
+	doUpgrade 1.30
+}
+
 @test "Basic Kubernetes Tests for 1.30" {
 	doSkip 1.30
 	export KUBECONFIG="$TARGET_KUBECONFIG"


### PR DESCRIPTION
Enable upgrade tests for OLVM

Adjust upgrade starting points based on actual Kubernetes versions being used by all tests.